### PR TITLE
Fix extension build output paths

### DIFF
--- a/apps/extension/public/options.html
+++ b/apps/extension/public/options.html
@@ -4,10 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Clipboard Share – Options</title>
-    <link href="../src/styles/tailwind.css" rel="stylesheet">
   </head>
   <body class="bg-white dark:bg-gray-900 min-w-[320px] min-h-[400px]">
     <div id="root"></div>
-    <script type="module" src="../src/options.tsx"></script>
+    <script type="module" src="options.js"></script>
   </body>
 </html>

--- a/apps/extension/public/popup.html
+++ b/apps/extension/public/popup.html
@@ -4,10 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Clipboard Share</title>
-    <link href="../src/styles/tailwind.css" rel="stylesheet">
   </head>
   <body class="bg-white dark:bg-gray-900 min-w-[320px] min-h-[180px]">
     <div id="root"></div>
-    <script type="module" src="../src/popup.tsx"></script>
+    <script type="module" src="popup.js"></script>
   </body>
 </html>

--- a/apps/extension/vite.config.ts
+++ b/apps/extension/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
           dest: ".",
         },
         {
-          src: resolve(__dirname, "public"),
+          src: resolve(__dirname, "public/*"),
           dest: ".",
         },
       ],


### PR DESCRIPTION
## Summary
- ensure popup/options HTML load compiled JS
- copy public assets to dist root when building

## Testing
- `npm test` *(fails: Missing script)*
- `npx vite build apps/extension` *(fails: npm 403 Forbidden due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_685e5d157cbc8328b80266e62dca502e