### PR TITLE
Remove reference to vitest types

### DIFF
--- a/apps/extension/tsconfig.json
+++ b/apps/extension/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["chrome", "node", "vitest", "jest"]
+    "types": ["chrome", "node", "jest"]
   },
   "include": ["src/**/*", "../../global.d.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "types": ["jest", "node", "vitest"]
+    "types": ["jest", "node"]
   },
   "include": ["packages/**/*", "tests/**/*", "global.d.ts"]
 }


### PR DESCRIPTION
## Summary
- clean up `tsconfig.json` and remove `vitest` from types
- update extension `tsconfig.json` to match

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68625a5f025483288174d5e0e4f5a4bf