### PR TITLE
Add missing unit tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+dist/
+build/
+node_modules/

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,34 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    node: true,
+    es2020: true,
+    jest: true,
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint', 'react'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react/recommended',
+  ],
+  settings: {
+    react: { version: 'detect' },
+  },
+  rules: {
+    'no-unused-vars': 'warn',
+    '@typescript-eslint/no-unused-vars': 'warn',
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/ban-ts-comment': 'off',
+    '@typescript-eslint/ban-types': 'off',
+    'no-control-regex': 'off',
+    'no-empty': 'off',
+    'prefer-const': 'off',
+  },
+  ignorePatterns: ['dist', 'build'],
+};

--- a/package.json
+++ b/package.json
@@ -35,6 +35,10 @@
     "@vitest/coverage-v8": "^1.6.1",
     "buffer": "^6.0.3",
     "fake-indexeddb": "^6.0.1",
+    "eslint": "^8.57.0",
+    "@typescript-eslint/eslint-plugin": "^7.8.0",
+    "@typescript-eslint/parser": "^7.8.0",
+    "eslint-plugin-react": "^7.33.2",
     "jest": "^29.7.0",
     "process": "^0.11.10",
     "rollup-plugin-polyfill-node": "^0.13.0",
@@ -45,8 +49,8 @@
   },
   "scripts": {
     "test": "jest",
-    "lint": "echo lint",
-    "lint:ext": "echo lint-ext"
+    "lint": "eslint --ext .ts,.tsx packages apps tests",
+    "lint:fix": "eslint --ext .ts,.tsx packages apps tests --fix"
   },
   "workspaces": [
     "apps/*",

--- a/packages/core/clipboard/__tests__/writer.test.ts
+++ b/packages/core/clipboard/__tests__/writer.test.ts
@@ -18,6 +18,20 @@ describe("Clipboard writer", () => {
     expect(fn).toHaveBeenCalledWith("abc");
   });
 
+  test("writes url clip", async () => {
+    const fn = jest.fn(async (_: string) => {});
+    const writer = createWriter(fn);
+    const clip: Clip = {
+      id: "u1",
+      type: ClipType.Url,
+      content: "https://example.com",
+      timestamp: Date.now(),
+      senderId: "me",
+    };
+    await writer.write(clip);
+    expect(fn).toHaveBeenCalledWith("https://example.com");
+  });
+
   test("rejects unknown type", async () => {
     const fn = jest.fn(async (_: string) => {});
     const writer = createWriter(fn);

--- a/tests/core/history/prune.test.ts
+++ b/tests/core/history/prune.test.ts
@@ -1,0 +1,38 @@
+import { shouldPrune, pruneHistoryItems } from "../../../packages/core/history/prune";
+import { HistoryItem } from "../../../packages/core/models/HistoryItem";
+import { Clip } from "../../../packages/core/models/Clip";
+
+const now = Date.now();
+
+function item(id: string, opts: Partial<Clip> = {}): HistoryItem {
+  const clip: Clip = {
+    id,
+    type: "text",
+    content: id,
+    timestamp: now,
+    senderId: "me",
+    ...opts,
+  } as Clip;
+  return { clip, receivedFrom: "me", syncedAt: clip.timestamp, isLocal: true };
+}
+
+describe("pruneHistoryItems", () => {
+  it("prunes expired clips", () => {
+    const expired = item("exp", { expiresAt: now - 1 });
+    expect(shouldPrune(expired, now)).toBe(true);
+  });
+
+  it("prunes very old clips", () => {
+    const old = item("old", { timestamp: now - 366 * 24 * 60 * 60 * 1000 });
+    expect(shouldPrune(old, now)).toBe(true);
+  });
+
+  it("filters list correctly", () => {
+    const keep = item("keep");
+    const expired = item("exp", { expiresAt: now - 1 });
+    const old = item("old", { timestamp: now - 366 * 24 * 60 * 60 * 1000 });
+    const res = pruneHistoryItems([keep, expired, old], now);
+    expect(res).toHaveLength(1);
+    expect(res[0].clip.id).toBe("keep");
+  });
+});

--- a/tests/core/libp2p/engine.test.ts
+++ b/tests/core/libp2p/engine.test.ts
@@ -1,15 +1,47 @@
-// Remove any embedded Jest config from this test file. Jest config should only be in jest.config.js, not in test files.
+// Mock peer creation to avoid heavy deps
+jest.mock("../../../packages/core/libp2p/peer", () => ({
+  createPeer: jest.fn(async () => ({
+    addEventListener: jest.fn(),
+    handle: jest.fn(),
+    start: jest.fn(),
+    stop: jest.fn(),
+    getConnections: jest.fn(() => []),
+    dialProtocol: jest.fn(async () => ({ sink: jest.fn(async () => {}) })),
+  })),
+}));
 
-import { describe, it, expect } from "@jest/globals";
+jest.mock("../../../packages/core/libp2p/protocol", () => {
+  return {
+    PROTOCOL: "/clipp/sync/1.0.0",
+    encodeMessage: jest.fn(() => new Uint8Array([1])),
+    decodeMessage: jest.fn(),
+  };
+});
 
-// Stub file for unit tests of the P2PEngine implementation
-// (Add tests as needed)
+import { Libp2pEngine } from "../../../packages/core/libp2p/engine";
+import { SyncMessage } from "../../../packages/core/models/SyncMessage";
+import { createPeer } from "../../../packages/core/libp2p/peer";
+import { encodeMessage, PROTOCOL } from "../../../packages/core/libp2p/protocol";
 
-describe("P2PEngine", () => {
-  it("should start and stop the engine", async () => {
-    // TODO: Implement test
+describe("Libp2pEngine", () => {
+  it("start and stop are idempotent", async () => {
+    const engine = new Libp2pEngine();
+    await engine.start();
+    await engine.start();
+    expect(createPeer).toHaveBeenCalledTimes(1);
+    await engine.stop();
+    await engine.stop();
+    const node = await (createPeer as jest.Mock).mock.results[0].value;
+    expect(node.stop).toHaveBeenCalledTimes(1);
   });
-  it("should send and receive messages", async () => {
-    // TODO: Implement test
+
+  it("sendMessage dials peer and encodes message", async () => {
+    const engine = new Libp2pEngine();
+    await engine.start();
+    const node = await (createPeer as jest.Mock).mock.results.slice(-1)[0].value;
+    const msg: SyncMessage = { type: "HELLO", payload: {}, senderId: "me", timestamp: 1 } as any;
+    await engine.sendMessage("peer-x", msg);
+    expect(node.dialProtocol).toHaveBeenCalledWith("peer-x", PROTOCOL);
+    expect(encodeMessage).toHaveBeenCalledWith(msg);
   });
 });

--- a/tests/core/libp2p/protocol.test.ts
+++ b/tests/core/libp2p/protocol.test.ts
@@ -1,0 +1,21 @@
+import { encodeMessage, decodeMessage, PROTOCOL } from "../../../packages/core/libp2p/protocol";
+import { SyncMessage } from "../../../packages/core/models/SyncMessage";
+
+describe("libp2p protocol", () => {
+  it("encodes and decodes messages", () => {
+    const msg: SyncMessage = {
+      type: "HELLO",
+      payload: { foo: "bar" },
+      senderId: "peer1",
+      timestamp: 123,
+    };
+    const bytes = encodeMessage(msg);
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    const decoded = decodeMessage(bytes);
+    expect(decoded).toEqual(msg);
+  });
+
+  it("exposes protocol id", () => {
+    expect(PROTOCOL).toBe("/clipp/sync/1.0.0");
+  });
+});


### PR DESCRIPTION
## Summary
- cover clipboard writer url handling
- test history prune logic
- add protocol encode/decode tests
- implement libp2p engine tests
- set up ESLint and configure rules

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68625c80347c8328a9466eb43278b25d