### PR TITLE
Fix bootstrap plugin handling

### DIFF
--- a/packages/core/network/node.ts
+++ b/packages/core/network/node.ts
@@ -15,12 +15,18 @@ export async function createClipboardNode(
   options: { peerId?: any; bootstrapList?: string[] } = {}
 ) {
   const { peerId, bootstrapList = [] } = options;
+  const discovery: any[] = [];
+  if (bootstrapList.length > 0) {
+    discovery.push(bootstrap({ list: bootstrapList }));
+  }
+  discovery.push(mdns());
+
   return await createLibp2p({
     ...(peerId ? { peerId } : {}),
     transports: [webRTC(), webSockets()],
     connectionEncrypters: [noise()],
     streamMuxers: [mplex()],
-    peerDiscovery: [bootstrap({ list: bootstrapList }), mdns()],
+    peerDiscovery: discovery,
     services: {
       pubsub: gossipsub(),
       dht: kadDHT() as any,


### PR DESCRIPTION
## Summary
- skip bootstrap discovery when no peers are provided

## Testing
- `npm test` *(fails: Your test suite must contain at least one test)*

------
https://chatgpt.com/codex/tasks/task_e_68628cf729488328b319d505a86ed9a1