### PR TITLE
Fix missing identify service for libp2p

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@chainsafe/libp2p-gossipsub": "^14.1.1",
         "@chainsafe/libp2p-noise": "^16.1.3",
         "@libp2p/bootstrap": "^11.0.35",
+        "@libp2p/identify": "^3.0.37",
         "@libp2p/kad-dht": "^15.0.2",
         "@libp2p/mdns": "^11.0.35",
         "@libp2p/mplex": "^11.0.35",
@@ -1840,30 +1841,55 @@
       }
     },
     "node_modules/@libp2p/crypto": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.1.tgz",
-      "integrity": "sha512-feByJ5ypBfl7Dp+jLBmieHDY/249hqCiDn8u6DNSZrpDhefn2l/NE03fS2mW6pLOnY3QIqB372TfLtx3/EPU+w==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.7.tgz",
+      "integrity": "sha512-7DO0piidLEKfCuNfS420BlHG0e2tH7W/zugdsPSiC/1Apa/s1B1dBkaIEgfDkGjrRP4S/8Or86Rtq7zXeEu67g==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^2.9.0",
-        "@noble/curves": "^1.7.0",
-        "@noble/hashes": "^1.6.1",
-        "multiformats": "^13.3.1",
+        "@libp2p/interface": "^2.10.5",
+        "@noble/curves": "^1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "multiformats": "^13.3.6",
+        "protons-runtime": "^5.5.0",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/identify": {
+      "version": "3.0.37",
+      "resolved": "https://registry.npmjs.org/@libp2p/identify/-/identify-3.0.37.tgz",
+      "integrity": "sha512-oDdNZaP6a0eH3UIXBee4gOeOT4U4krfOAbqfqe/pM6exQqTyvzv21lOuFvC5EKgOYw63NoNPw1Iwnk36hDBpTg==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@libp2p/crypto": "^5.1.7",
+        "@libp2p/interface": "^2.10.5",
+        "@libp2p/interface-internal": "^2.3.18",
+        "@libp2p/peer-id": "^5.1.8",
+        "@libp2p/peer-record": "^8.0.34",
+        "@libp2p/utils": "^6.7.1",
+        "@multiformats/multiaddr": "^12.4.4",
+        "@multiformats/multiaddr-matcher": "^1.7.2",
+        "it-drain": "^3.0.9",
+        "it-parallel": "^3.0.11",
+        "it-protobuf-stream": "^2.0.2",
+        "main-event": "^1.0.1",
         "protons-runtime": "^5.5.0",
         "uint8arraylist": "^2.4.8",
         "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/interface": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-2.9.0.tgz",
-      "integrity": "sha512-L/0Z5H0mjaECA0jkZG+OJmEhB/OIJ07gzZYljU7C19XjL3dSkBvhA9il+G3FpHyHgqAOVGuQU5qkbv2Edj8FIA==",
+      "version": "2.10.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-2.10.5.tgz",
+      "integrity": "sha512-Z52n04Mph/myGdwyExbFi5S/HqrmZ9JOmfLc2v4r2Cik3GRdw98vrGH19PFvvwjLwAjaqsweCtlGaBzAz09YDw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@multiformats/multiaddr": "^12.3.3",
+        "@multiformats/dns": "^1.0.6",
+        "@multiformats/multiaddr": "^12.4.4",
         "it-pushable": "^3.2.3",
         "it-stream-types": "^2.0.2",
-        "multiformats": "^13.3.1",
+        "main-event": "^1.0.1",
+        "multiformats": "^13.3.6",
         "progress-events": "^1.0.1",
         "uint8arraylist": "^2.4.8"
       }
@@ -1886,14 +1912,14 @@
       }
     },
     "node_modules/@libp2p/interface-internal": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-2.3.11.tgz",
-      "integrity": "sha512-/7GMkn8F9ojFgUmgkiyP0LeVQ4AKinyn2PdFCPOzQszcN3rVHOi6mtZYXNsGjftoP3QZQ4udadbytzGE3pmVYA==",
+      "version": "2.3.18",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-2.3.18.tgz",
+      "integrity": "sha512-tnZ20IFASXLbDc2JxeUPZNIXDuN5Ge7be6BU458WLvmquf93NlSqZkWs6xFdi+0yXUrw7GGTgzIP5v+1LnDUmA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^2.9.0",
-        "@libp2p/peer-collections": "^6.0.27",
-        "@multiformats/multiaddr": "^12.3.3",
+        "@libp2p/interface": "^2.10.5",
+        "@libp2p/peer-collections": "^6.0.34",
+        "@multiformats/multiaddr": "^12.4.4",
         "progress-events": "^1.0.1"
       }
     },
@@ -2094,15 +2120,15 @@
       }
     },
     "node_modules/@libp2p/logger": {
-      "version": "5.1.15",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-5.1.15.tgz",
-      "integrity": "sha512-0+rOHEXXDNZvsb9p04jVAFQB0WcvMxFfqzSe271/tg4yVlPF5H99l5BwOqeb+EYhHV1lTk+zrJdPK9easHr1fQ==",
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-5.1.21.tgz",
+      "integrity": "sha512-V1TWlZM5BuKkiGQ7En4qOnseVP82JwDIpIfNjceUZz1ArL32A5HXJjLQnJchkZ3VW8PVciJzUos/vP6slhPY6Q==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^2.9.0",
-        "@multiformats/multiaddr": "^12.3.3",
+        "@libp2p/interface": "^2.10.5",
+        "@multiformats/multiaddr": "^12.4.4",
         "interface-datastore": "^8.3.1",
-        "multiformats": "^13.3.1",
+        "multiformats": "^13.3.6",
         "weald": "^1.0.4"
       }
     },
@@ -2156,41 +2182,41 @@
       }
     },
     "node_modules/@libp2p/peer-collections": {
-      "version": "6.0.27",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-6.0.27.tgz",
-      "integrity": "sha512-JLA7N9OgcxfxnSU3IpZ1DLXHCW64VH/WgJm/lFtPXjIfknO0hU2feerdB2sz/QBAAmehJHqBBSlao57BKo7KLg==",
+      "version": "6.0.34",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-6.0.34.tgz",
+      "integrity": "sha512-rw8gDGhou4sF6W6i9ntmRARFePX19Dw9MMVpZHr6Kx9q2kvBJq91IXUzsXP06roexEOu1CUlZwxtUAqOBy+Eww==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^2.9.0",
-        "@libp2p/peer-id": "^5.1.2",
-        "@libp2p/utils": "^6.6.2",
-        "multiformats": "^13.3.1"
+        "@libp2p/interface": "^2.10.5",
+        "@libp2p/peer-id": "^5.1.8",
+        "@libp2p/utils": "^6.7.1",
+        "multiformats": "^13.3.6"
       }
     },
     "node_modules/@libp2p/peer-id": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-5.1.2.tgz",
-      "integrity": "sha512-K4tjLi+OIHJSeMMqw28xnBxDfklfWCsR423Jm6GxZ5avIj2xm7WIq5oUhCntGGDIQWW/8qdf8v3tYK36JxwLOA==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-5.1.8.tgz",
+      "integrity": "sha512-pGaM4BwjnXdGtAtd84L4/wuABpsnFYE+AQ+h3GxNFme0IsTaTVKWd1jBBE5YFeKHBHGUOhF3TlHsdjFfjQA7TA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.1",
-        "@libp2p/interface": "^2.9.0",
-        "multiformats": "^13.3.1",
+        "@libp2p/crypto": "^5.1.7",
+        "@libp2p/interface": "^2.10.5",
+        "multiformats": "^13.3.6",
         "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/peer-record": {
-      "version": "8.0.27",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-8.0.27.tgz",
-      "integrity": "sha512-F2sWv0++WrHRuEYtqqvFOa+748rCekQuEBj9OKvDCxS3gtQeEgVLfsNAvM/vRPN0Lx3m4OF44tui2KpV7NU6jA==",
+      "version": "8.0.34",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-8.0.34.tgz",
+      "integrity": "sha512-GqvRBpvclscoKuF0JUfLyZTv+BwzICBBe50LFiAKio8LijZMBr43b+AcEaSEwFWDwlWmaKU73q8EQLrCb/e67Q==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.1",
-        "@libp2p/interface": "^2.9.0",
-        "@libp2p/peer-id": "^5.1.2",
-        "@libp2p/utils": "^6.6.2",
-        "@multiformats/multiaddr": "^12.3.3",
-        "multiformats": "^13.3.1",
+        "@libp2p/crypto": "^5.1.7",
+        "@libp2p/interface": "^2.10.5",
+        "@libp2p/peer-id": "^5.1.8",
+        "@libp2p/utils": "^6.7.1",
+        "@multiformats/multiaddr": "^12.4.4",
+        "multiformats": "^13.3.6",
         "protons-runtime": "^5.5.0",
         "uint8-varint": "^2.0.4",
         "uint8arraylist": "^2.4.8",
@@ -2264,32 +2290,46 @@
       }
     },
     "node_modules/@libp2p/utils": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-6.6.2.tgz",
-      "integrity": "sha512-PjbKA0+l+8mmM7quOnG0D7XKdlF/3Hi5Aco3D0ZQXW68QnzmjEEeTbky1gzrZUgnMBmb2ZYrBlZd0GpsJ7Rc9Q==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-6.7.1.tgz",
+      "integrity": "sha512-x3WImvw4unmx1ZeAedj8AkRe4UImUlkw0ZItYAiKiekElMNUXwv+Yt48dI/LmB38JIof8sng29XvUeCVU3F6OA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@chainsafe/is-ip": "^2.0.2",
+        "@chainsafe/is-ip": "^2.1.0",
         "@chainsafe/netmask": "^2.0.0",
-        "@libp2p/crypto": "^5.1.1",
-        "@libp2p/interface": "^2.9.0",
-        "@libp2p/logger": "^5.1.15",
-        "@multiformats/multiaddr": "^12.3.3",
+        "@libp2p/crypto": "^5.1.7",
+        "@libp2p/interface": "^2.10.5",
+        "@libp2p/logger": "^5.1.21",
+        "@multiformats/multiaddr": "^12.4.4",
         "@sindresorhus/fnv1a": "^3.1.0",
         "any-signal": "^4.1.1",
         "delay": "^6.0.0",
         "get-iterator": "^2.0.1",
         "is-loopback-addr": "^2.0.2",
-        "it-foreach": "^2.1.1",
+        "is-plain-obj": "^4.1.0",
+        "it-foreach": "^2.1.3",
         "it-pipe": "^3.0.1",
         "it-pushable": "^3.2.3",
         "it-stream-types": "^2.0.2",
+        "main-event": "^1.0.1",
         "netmask": "^2.0.2",
         "p-defer": "^4.0.1",
         "race-event": "^1.3.0",
-        "race-signal": "^1.1.2",
+        "race-signal": "^1.1.3",
         "uint8arraylist": "^2.4.8",
         "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/utils/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@libp2p/webrtc": {
@@ -2621,14 +2661,15 @@
       }
     },
     "node_modules/@multiformats/multiaddr": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.4.0.tgz",
-      "integrity": "sha512-FL7yBTLijJ5JkO044BGb2msf+uJLrwpD6jD6TkXlbjA9N12+18HT40jvd4o5vL4LOJMc86dPX6tGtk/uI9kYKg==",
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.5.1.tgz",
+      "integrity": "sha512-+DDlr9LIRUS8KncI1TX/FfUn8F2dl6BIxJgshS/yFQCNB5IAF0OGzcwB39g5NLE22s4qqDePv0Qof6HdpJ/4aQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1",
         "@chainsafe/netmask": "^2.0.0",
         "@multiformats/dns": "^1.0.3",
+        "abort-error": "^1.0.1",
         "multiformats": "^13.0.0",
         "uint8-varint": "^2.0.1",
         "uint8arrays": "^5.0.0"
@@ -9524,6 +9565,12 @@
         "source-map-js": "^1.2.0"
       }
     },
+    "node_modules/main-event": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/main-event/-/main-event-1.0.1.tgz",
+      "integrity": "sha512-NWtdGrAca/69fm6DIVd8T9rtfDII4Q8NQbIbsKQq2VzS9eqOGYs8uaNQjcuaCq/d9H/o625aOTJX2Qoxzqw0Pw==",
+      "license": "Apache-2.0 OR MIT"
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -10109,9 +10156,9 @@
       }
     },
     "node_modules/multiformats": {
-      "version": "13.3.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.3.4.tgz",
-      "integrity": "sha512-JXpM5p9TpJ/BHsUtmLaWuRN0ft0gJPGa6BhkX2KXjFHvkFQOQkDManoar3gx0JsTLNrOojBE2Mj4hFxohGnXZA==",
+      "version": "13.3.7",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.3.7.tgz",
+      "integrity": "sha512-meL9DERHj+fFVWoOX9fXqfcYcSpUfSYJPcFvDPKrxitICbwAoWR+Ut4j5NO9zAT917HUHLQmqzQbAsGNHlDcxQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/nanoid": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "@chainsafe/libp2p-gossipsub": "^14.1.1",
     "@chainsafe/libp2p-noise": "^16.1.3",
     "@libp2p/bootstrap": "^11.0.35",
+    "@libp2p/identify": "^3.0.37",
     "@libp2p/kad-dht": "^15.0.2",
     "@libp2p/mdns": "^11.0.35",
     "@libp2p/mplex": "^11.0.35",

--- a/packages/core/libp2p/transport.ts
+++ b/packages/core/libp2p/transport.ts
@@ -6,6 +6,7 @@ import { webRTC } from "@libp2p/webrtc";
 import { mplex } from "@libp2p/mplex";
 import { noise } from "@chainsafe/libp2p-noise";
 import { mdns } from "@libp2p/mdns";
+import { identify } from "@libp2p/identify";
 
 export async function createTransportConfig(
   peerId: any
@@ -18,5 +19,8 @@ export async function createTransportConfig(
     streamMuxers: [mplex()],
     connectionEncryption: [noise()],
     peerDiscovery: [mdns(), wrtcStar.discovery],
+    services: {
+      identify: identify(),
+    },
   };
 }

--- a/packages/core/network/node.ts
+++ b/packages/core/network/node.ts
@@ -10,6 +10,7 @@ import { bootstrap } from "@libp2p/bootstrap";
 import { mdns } from "@libp2p/mdns";
 import { gossipsub } from "@chainsafe/libp2p-gossipsub";
 import { kadDHT } from "@libp2p/kad-dht";
+import { identify } from "@libp2p/identify";
 
 export async function createClipboardNode(
   options: { peerId?: any; bootstrapList?: string[] } = {}
@@ -30,6 +31,7 @@ export async function createClipboardNode(
     services: {
       pubsub: gossipsub(),
       dht: kadDHT() as any,
+      identify: identify(),
     },
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -315,7 +315,7 @@
   resolved "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-1.0.1.tgz"
   integrity sha512-4Y/kQm0LsJ6QRtGcMq6gOdQP+fZhWDfIV2eIqP6oFJZBWYGmdh3wm8YbrXDPLJO87X2Fu6koRLdUS00O3k14Hw==
 
-"@chainsafe/is-ip@^2.0.1", "@chainsafe/is-ip@^2.0.2":
+"@chainsafe/is-ip@^2.0.1", "@chainsafe/is-ip@^2.0.2", "@chainsafe/is-ip@^2.1.0":
   version "2.1.0"
   resolved "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.1.0.tgz"
   integrity sha512-KIjt+6IfysQ4GCv66xihEitBjvhU/bixbbbFxdJ1sqCp4uJ0wuZiYBPhksZoy4lfaF0k9cwNzY5upEW/VWdw3w==
@@ -971,15 +971,36 @@
     "@multiformats/mafmt" "^12.1.6"
     "@multiformats/multiaddr" "^12.3.3"
 
-"@libp2p/crypto@^5.0.0", "@libp2p/crypto@^5.1.1":
-  version "5.1.1"
-  resolved "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.1.tgz"
-  integrity sha512-feByJ5ypBfl7Dp+jLBmieHDY/249hqCiDn8u6DNSZrpDhefn2l/NE03fS2mW6pLOnY3QIqB372TfLtx3/EPU+w==
+"@libp2p/crypto@^5.0.0", "@libp2p/crypto@^5.1.1", "@libp2p/crypto@^5.1.7":
+  version "5.1.7"
+  resolved "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.7.tgz"
+  integrity sha512-7DO0piidLEKfCuNfS420BlHG0e2tH7W/zugdsPSiC/1Apa/s1B1dBkaIEgfDkGjrRP4S/8Or86Rtq7zXeEu67g==
   dependencies:
-    "@libp2p/interface" "^2.9.0"
-    "@noble/curves" "^1.7.0"
-    "@noble/hashes" "^1.6.1"
-    multiformats "^13.3.1"
+    "@libp2p/interface" "^2.10.5"
+    "@noble/curves" "^1.9.1"
+    "@noble/hashes" "^1.8.0"
+    multiformats "^13.3.6"
+    protons-runtime "^5.5.0"
+    uint8arraylist "^2.4.8"
+    uint8arrays "^5.1.0"
+
+"@libp2p/identify@^3.0.37":
+  version "3.0.37"
+  resolved "https://registry.npmjs.org/@libp2p/identify/-/identify-3.0.37.tgz"
+  integrity sha512-oDdNZaP6a0eH3UIXBee4gOeOT4U4krfOAbqfqe/pM6exQqTyvzv21lOuFvC5EKgOYw63NoNPw1Iwnk36hDBpTg==
+  dependencies:
+    "@libp2p/crypto" "^5.1.7"
+    "@libp2p/interface" "^2.10.5"
+    "@libp2p/interface-internal" "^2.3.18"
+    "@libp2p/peer-id" "^5.1.8"
+    "@libp2p/peer-record" "^8.0.34"
+    "@libp2p/utils" "^6.7.1"
+    "@multiformats/multiaddr" "^12.4.4"
+    "@multiformats/multiaddr-matcher" "^1.7.2"
+    it-drain "^3.0.9"
+    it-parallel "^3.0.11"
+    it-protobuf-stream "^2.0.2"
+    main-event "^1.0.1"
     protons-runtime "^5.5.0"
     uint8arraylist "^2.4.8"
     uint8arrays "^5.1.0"
@@ -995,14 +1016,14 @@
     it-stream-types "^2.0.1"
     uint8arraylist "^2.4.3"
 
-"@libp2p/interface-internal@^2.0.0", "@libp2p/interface-internal@^2.3.11":
-  version "2.3.11"
-  resolved "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-2.3.11.tgz"
-  integrity sha512-/7GMkn8F9ojFgUmgkiyP0LeVQ4AKinyn2PdFCPOzQszcN3rVHOi6mtZYXNsGjftoP3QZQ4udadbytzGE3pmVYA==
+"@libp2p/interface-internal@^2.0.0", "@libp2p/interface-internal@^2.3.11", "@libp2p/interface-internal@^2.3.18":
+  version "2.3.18"
+  resolved "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-2.3.18.tgz"
+  integrity sha512-tnZ20IFASXLbDc2JxeUPZNIXDuN5Ge7be6BU458WLvmquf93NlSqZkWs6xFdi+0yXUrw7GGTgzIP5v+1LnDUmA==
   dependencies:
-    "@libp2p/interface" "^2.9.0"
-    "@libp2p/peer-collections" "^6.0.27"
-    "@multiformats/multiaddr" "^12.3.3"
+    "@libp2p/interface" "^2.10.5"
+    "@libp2p/peer-collections" "^6.0.34"
+    "@multiformats/multiaddr" "^12.4.4"
     progress-events "^1.0.1"
 
 "@libp2p/interface-peer-discovery@^1.0.0":
@@ -1053,15 +1074,17 @@
     "@multiformats/multiaddr" "^12.0.0"
     it-stream-types "^2.0.1"
 
-"@libp2p/interface@^2.0.0", "@libp2p/interface@^2.9.0":
-  version "2.9.0"
-  resolved "https://registry.npmjs.org/@libp2p/interface/-/interface-2.9.0.tgz"
-  integrity sha512-L/0Z5H0mjaECA0jkZG+OJmEhB/OIJ07gzZYljU7C19XjL3dSkBvhA9il+G3FpHyHgqAOVGuQU5qkbv2Edj8FIA==
+"@libp2p/interface@^2.0.0", "@libp2p/interface@^2.10.5", "@libp2p/interface@^2.9.0":
+  version "2.10.5"
+  resolved "https://registry.npmjs.org/@libp2p/interface/-/interface-2.10.5.tgz"
+  integrity sha512-Z52n04Mph/myGdwyExbFi5S/HqrmZ9JOmfLc2v4r2Cik3GRdw98vrGH19PFvvwjLwAjaqsweCtlGaBzAz09YDw==
   dependencies:
-    "@multiformats/multiaddr" "^12.3.3"
+    "@multiformats/dns" "^1.0.6"
+    "@multiformats/multiaddr" "^12.4.4"
     it-pushable "^3.2.3"
     it-stream-types "^2.0.2"
-    multiformats "^13.3.1"
+    main-event "^1.0.1"
+    multiformats "^13.3.6"
     progress-events "^1.0.1"
     uint8arraylist "^2.4.8"
 
@@ -1144,15 +1167,15 @@
     interface-datastore "^8.2.0"
     multiformats "^11.0.2"
 
-"@libp2p/logger@^5.0.1", "@libp2p/logger@^5.1.15":
-  version "5.1.15"
-  resolved "https://registry.npmjs.org/@libp2p/logger/-/logger-5.1.15.tgz"
-  integrity sha512-0+rOHEXXDNZvsb9p04jVAFQB0WcvMxFfqzSe271/tg4yVlPF5H99l5BwOqeb+EYhHV1lTk+zrJdPK9easHr1fQ==
+"@libp2p/logger@^5.0.1", "@libp2p/logger@^5.1.15", "@libp2p/logger@^5.1.21":
+  version "5.1.21"
+  resolved "https://registry.npmjs.org/@libp2p/logger/-/logger-5.1.21.tgz"
+  integrity sha512-V1TWlZM5BuKkiGQ7En4qOnseVP82JwDIpIfNjceUZz1ArL32A5HXJjLQnJchkZ3VW8PVciJzUos/vP6slhPY6Q==
   dependencies:
-    "@libp2p/interface" "^2.9.0"
-    "@multiformats/multiaddr" "^12.3.3"
+    "@libp2p/interface" "^2.10.5"
+    "@multiformats/multiaddr" "^12.4.4"
     interface-datastore "^8.3.1"
-    multiformats "^13.3.1"
+    multiformats "^13.3.6"
     weald "^1.0.4"
 
 "@libp2p/mdns@^11.0.35":
@@ -1198,15 +1221,15 @@
     uint8arraylist "^2.4.8"
     uint8arrays "^5.1.0"
 
-"@libp2p/peer-collections@^6.0.27":
-  version "6.0.27"
-  resolved "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-6.0.27.tgz"
-  integrity sha512-JLA7N9OgcxfxnSU3IpZ1DLXHCW64VH/WgJm/lFtPXjIfknO0hU2feerdB2sz/QBAAmehJHqBBSlao57BKo7KLg==
+"@libp2p/peer-collections@^6.0.27", "@libp2p/peer-collections@^6.0.34":
+  version "6.0.34"
+  resolved "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-6.0.34.tgz"
+  integrity sha512-rw8gDGhou4sF6W6i9ntmRARFePX19Dw9MMVpZHr6Kx9q2kvBJq91IXUzsXP06roexEOu1CUlZwxtUAqOBy+Eww==
   dependencies:
-    "@libp2p/interface" "^2.9.0"
-    "@libp2p/peer-id" "^5.1.2"
-    "@libp2p/utils" "^6.6.2"
-    multiformats "^13.3.1"
+    "@libp2p/interface" "^2.10.5"
+    "@libp2p/peer-id" "^5.1.8"
+    "@libp2p/utils" "^6.7.1"
+    multiformats "^13.3.6"
 
 "@libp2p/peer-id@^2.0.0":
   version "2.0.4"
@@ -1218,27 +1241,27 @@
     multiformats "^11.0.0"
     uint8arrays "^4.0.2"
 
-"@libp2p/peer-id@^5.0.0", "@libp2p/peer-id@^5.1.2":
-  version "5.1.2"
-  resolved "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-5.1.2.tgz"
-  integrity sha512-K4tjLi+OIHJSeMMqw28xnBxDfklfWCsR423Jm6GxZ5avIj2xm7WIq5oUhCntGGDIQWW/8qdf8v3tYK36JxwLOA==
+"@libp2p/peer-id@^5.0.0", "@libp2p/peer-id@^5.1.2", "@libp2p/peer-id@^5.1.8":
+  version "5.1.8"
+  resolved "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-5.1.8.tgz"
+  integrity sha512-pGaM4BwjnXdGtAtd84L4/wuABpsnFYE+AQ+h3GxNFme0IsTaTVKWd1jBBE5YFeKHBHGUOhF3TlHsdjFfjQA7TA==
   dependencies:
-    "@libp2p/crypto" "^5.1.1"
-    "@libp2p/interface" "^2.9.0"
-    multiformats "^13.3.1"
+    "@libp2p/crypto" "^5.1.7"
+    "@libp2p/interface" "^2.10.5"
+    multiformats "^13.3.6"
     uint8arrays "^5.1.0"
 
-"@libp2p/peer-record@^8.0.27":
-  version "8.0.27"
-  resolved "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-8.0.27.tgz"
-  integrity sha512-F2sWv0++WrHRuEYtqqvFOa+748rCekQuEBj9OKvDCxS3gtQeEgVLfsNAvM/vRPN0Lx3m4OF44tui2KpV7NU6jA==
+"@libp2p/peer-record@^8.0.27", "@libp2p/peer-record@^8.0.34":
+  version "8.0.34"
+  resolved "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-8.0.34.tgz"
+  integrity sha512-GqvRBpvclscoKuF0JUfLyZTv+BwzICBBe50LFiAKio8LijZMBr43b+AcEaSEwFWDwlWmaKU73q8EQLrCb/e67Q==
   dependencies:
-    "@libp2p/crypto" "^5.1.1"
-    "@libp2p/interface" "^2.9.0"
-    "@libp2p/peer-id" "^5.1.2"
-    "@libp2p/utils" "^6.6.2"
-    "@multiformats/multiaddr" "^12.3.3"
-    multiformats "^13.3.1"
+    "@libp2p/crypto" "^5.1.7"
+    "@libp2p/interface" "^2.10.5"
+    "@libp2p/peer-id" "^5.1.8"
+    "@libp2p/utils" "^6.7.1"
+    "@multiformats/multiaddr" "^12.4.4"
+    multiformats "^13.3.6"
     protons-runtime "^5.5.0"
     uint8-varint "^2.0.4"
     uint8arraylist "^2.4.8"
@@ -1302,30 +1325,32 @@
     uint8arraylist "^2.4.8"
     uint8arrays "^5.1.0"
 
-"@libp2p/utils@^6.6.2":
-  version "6.6.2"
-  resolved "https://registry.npmjs.org/@libp2p/utils/-/utils-6.6.2.tgz"
-  integrity sha512-PjbKA0+l+8mmM7quOnG0D7XKdlF/3Hi5Aco3D0ZQXW68QnzmjEEeTbky1gzrZUgnMBmb2ZYrBlZd0GpsJ7Rc9Q==
+"@libp2p/utils@^6.6.2", "@libp2p/utils@^6.7.1":
+  version "6.7.1"
+  resolved "https://registry.npmjs.org/@libp2p/utils/-/utils-6.7.1.tgz"
+  integrity sha512-x3WImvw4unmx1ZeAedj8AkRe4UImUlkw0ZItYAiKiekElMNUXwv+Yt48dI/LmB38JIof8sng29XvUeCVU3F6OA==
   dependencies:
-    "@chainsafe/is-ip" "^2.0.2"
+    "@chainsafe/is-ip" "^2.1.0"
     "@chainsafe/netmask" "^2.0.0"
-    "@libp2p/crypto" "^5.1.1"
-    "@libp2p/interface" "^2.9.0"
-    "@libp2p/logger" "^5.1.15"
-    "@multiformats/multiaddr" "^12.3.3"
+    "@libp2p/crypto" "^5.1.7"
+    "@libp2p/interface" "^2.10.5"
+    "@libp2p/logger" "^5.1.21"
+    "@multiformats/multiaddr" "^12.4.4"
     "@sindresorhus/fnv1a" "^3.1.0"
     any-signal "^4.1.1"
     delay "^6.0.0"
     get-iterator "^2.0.1"
     is-loopback-addr "^2.0.2"
-    it-foreach "^2.1.1"
+    is-plain-obj "^4.1.0"
+    it-foreach "^2.1.3"
     it-pipe "^3.0.1"
     it-pushable "^3.2.3"
     it-stream-types "^2.0.2"
+    main-event "^1.0.1"
     netmask "^2.0.2"
     p-defer "^4.0.1"
     race-event "^1.3.0"
-    race-signal "^1.1.2"
+    race-signal "^1.1.3"
     uint8arraylist "^2.4.8"
     uint8arrays "^5.1.0"
 
@@ -1453,7 +1478,7 @@
   dependencies:
     "@multiformats/multiaddr" "^12.0.0"
 
-"@multiformats/multiaddr-matcher@^1.6.0", "@multiformats/multiaddr-matcher@^1.7.0":
+"@multiformats/multiaddr-matcher@^1.6.0", "@multiformats/multiaddr-matcher@^1.7.0", "@multiformats/multiaddr-matcher@^1.7.2":
   version "1.7.2"
   resolved "https://registry.npmjs.org/@multiformats/multiaddr-matcher/-/multiaddr-matcher-1.7.2.tgz"
   integrity sha512-BJzHOBAAxGZKw+FY/MzeIKGKERAW/1XOrpj61wgzZVvR/iksyGTQhliyTgmuakpBJPSsCxlrk3eLemVhZuJIFQ==
@@ -1469,14 +1494,15 @@
   dependencies:
     "@multiformats/multiaddr" "^12.3.0"
 
-"@multiformats/multiaddr@^12.0.0", "@multiformats/multiaddr@^12.1.14", "@multiformats/multiaddr@^12.1.2", "@multiformats/multiaddr@^12.1.3", "@multiformats/multiaddr@^12.3.0", "@multiformats/multiaddr@^12.3.3", "@multiformats/multiaddr@^12.3.5", "@multiformats/multiaddr@^12.4.0":
-  version "12.4.0"
-  resolved "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.4.0.tgz"
-  integrity sha512-FL7yBTLijJ5JkO044BGb2msf+uJLrwpD6jD6TkXlbjA9N12+18HT40jvd4o5vL4LOJMc86dPX6tGtk/uI9kYKg==
+"@multiformats/multiaddr@^12.0.0", "@multiformats/multiaddr@^12.1.14", "@multiformats/multiaddr@^12.1.2", "@multiformats/multiaddr@^12.1.3", "@multiformats/multiaddr@^12.3.0", "@multiformats/multiaddr@^12.3.3", "@multiformats/multiaddr@^12.3.5", "@multiformats/multiaddr@^12.4.0", "@multiformats/multiaddr@^12.4.4":
+  version "12.5.1"
+  resolved "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.5.1.tgz"
+  integrity sha512-+DDlr9LIRUS8KncI1TX/FfUn8F2dl6BIxJgshS/yFQCNB5IAF0OGzcwB39g5NLE22s4qqDePv0Qof6HdpJ/4aQ==
   dependencies:
     "@chainsafe/is-ip" "^2.0.1"
     "@chainsafe/netmask" "^2.0.0"
     "@multiformats/dns" "^1.0.3"
+    abort-error "^1.0.1"
     multiformats "^13.0.0"
     uint8-varint "^2.0.1"
     uint8arrays "^5.0.0"
@@ -1486,14 +1512,14 @@
   resolved "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz"
   integrity sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==
 
-"@noble/curves@^1.1.0", "@noble/curves@^1.7.0":
+"@noble/curves@^1.1.0", "@noble/curves@^1.9.1":
   version "1.9.1"
   resolved "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz"
   integrity sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==
   dependencies:
     "@noble/hashes" "1.8.0"
 
-"@noble/hashes@^1.3.1", "@noble/hashes@^1.6.1", "@noble/hashes@1.8.0":
+"@noble/hashes@^1.3.1", "@noble/hashes@^1.6.1", "@noble/hashes@^1.8.0", "@noble/hashes@1.8.0":
   version "1.8.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
@@ -3746,7 +3772,7 @@ exponential-backoff@^3.1.1:
   resolved "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz"
   integrity sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==
 
-"extension@file:/Users/invine/src/js/clipp/apps/extension":
+"extension@file:/workspace/clipp/apps/extension":
   version "0.0.0"
   resolved "file:apps/extension"
   dependencies:
@@ -4485,6 +4511,11 @@ is-plain-obj@^2.1.0:
   resolved "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
+is-plain-obj@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz"
+  integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
+
 is-regex@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz"
@@ -4664,7 +4695,7 @@ it-byte-stream@^2.0.0, it-byte-stream@^2.0.1:
     race-signal "^1.1.3"
     uint8arraylist "^2.4.8"
 
-it-drain@^3.0.7:
+it-drain@^3.0.7, it-drain@^3.0.9:
   version "3.0.9"
   resolved "https://registry.npmjs.org/it-drain/-/it-drain-3.0.9.tgz"
   integrity sha512-HKy+UVYAqSFm+naEkNg14BwKymjHK0SxYLi8H5nACTIgbemDMZ4SNa2omzMUuk2Nu3jhaHMoqUJfZ0aBcdn4oA==
@@ -4676,7 +4707,7 @@ it-filter@^3.1.1:
   dependencies:
     it-peekable "^3.0.0"
 
-it-foreach@^2.1.1:
+it-foreach@^2.1.3:
   version "2.1.3"
   resolved "https://registry.npmjs.org/it-foreach/-/it-foreach-2.1.3.tgz"
   integrity sha512-QfrD0Sjv0Uy664huiZevAgY1UEsJ1GlmPpjwy38vjSi4rCmdGkO7ef/KKG86ZXd9j+j1bXXGnfDLjCs7lU8A0A==
@@ -4743,7 +4774,7 @@ it-pair@^2.0.6:
     it-stream-types "^2.0.1"
     p-defer "^4.0.0"
 
-it-parallel@^3.0.8:
+it-parallel@^3.0.11, it-parallel@^3.0.8:
   version "3.0.11"
   resolved "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.11.tgz"
   integrity sha512-ABHAwLO6RMB9zBKUN1v7pJWupwGaMkUrtGNnygDqog5yB8PjyKWxUKLwca1OHuZrdnkOx0VzETEXMSzWrzX8bw==
@@ -4764,7 +4795,7 @@ it-pipe@^3.0.1:
     it-pushable "^3.1.2"
     it-stream-types "^2.0.1"
 
-it-protobuf-stream@^2.0.1:
+it-protobuf-stream@^2.0.1, it-protobuf-stream@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/it-protobuf-stream/-/it-protobuf-stream-2.0.2.tgz"
   integrity sha512-40abXOZL3jQYkD/+VhabchZadtvq4cSRKMEhaXVYa58HPdkBSzyL3bUzMcERVcLq2ithLwrPyjLAVqMXud/mBA==
@@ -5446,6 +5477,11 @@ magicast@^0.3.3:
     "@babel/types" "^7.25.4"
     source-map-js "^1.2.0"
 
+main-event@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/main-event/-/main-event-1.0.1.tgz"
+  integrity sha512-NWtdGrAca/69fm6DIVd8T9rtfDII4Q8NQbIbsKQq2VzS9eqOGYs8uaNQjcuaCq/d9H/o625aOTJX2Qoxzqw0Pw==
+
 make-dir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz"
@@ -5823,10 +5859,10 @@ multiformats@^12.0.1:
   resolved "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz"
   integrity sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==
 
-multiformats@^13.0.0, multiformats@^13.0.1, multiformats@^13.3.1:
-  version "13.3.4"
-  resolved "https://registry.npmjs.org/multiformats/-/multiformats-13.3.4.tgz"
-  integrity sha512-JXpM5p9TpJ/BHsUtmLaWuRN0ft0gJPGa6BhkX2KXjFHvkFQOQkDManoar3gx0JsTLNrOojBE2Mj4hFxohGnXZA==
+multiformats@^13.0.0, multiformats@^13.0.1, multiformats@^13.3.1, multiformats@^13.3.6:
+  version "13.3.7"
+  resolved "https://registry.npmjs.org/multiformats/-/multiformats-13.3.7.tgz"
+  integrity sha512-meL9DERHj+fFVWoOX9fXqfcYcSpUfSYJPcFvDPKrxitICbwAoWR+Ut4j5NO9zAT917HUHLQmqzQbAsGNHlDcxQ==
 
 nanoid@^3.3.8:
   version "3.3.11"


### PR DESCRIPTION
## Summary
- add `@libp2p/identify` dependency
- enable identify service when creating libp2p nodes

## Testing
- `npm test` *(fails: Your test suite must contain at least one test)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6862907927108328b0d67ac5c0a59a35