### PR TITLE
Implement system clipboard listener using offscreen page

### DIFF
--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -37,5 +37,9 @@
     "32": "icon-32.png",
     "48": "icon-48.png",
     "128": "icon-128.png"
+  },
+  "offscreen": {
+    "page": "offscreen.html",
+    "persistent": true
   }
 }

--- a/apps/extension/offscreen.html
+++ b/apps/extension/offscreen.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+</head>
+<body>
+  <script type="module" src="src/offscreen.ts"></script>
+</body>
+</html>

--- a/apps/extension/src/offscreen.ts
+++ b/apps/extension/src/offscreen.ts
@@ -1,0 +1,17 @@
+let lastText = '';
+
+async function checkClipboard() {
+  try {
+    const text = await navigator.clipboard.readText();
+    if (text && text !== lastText) {
+      lastText = text;
+      await chrome.runtime.sendMessage({ type: 'clipboardUpdate', text });
+    }
+  } catch {
+    // ignore
+  }
+}
+
+setInterval(checkClipboard, 2000);
+// initial check
+void checkClipboard();

--- a/packages/core/clipboard/service.ts
+++ b/packages/core/clipboard/service.ts
@@ -33,8 +33,14 @@ export function createClipboardService(
   platform: "chrome" | "android",
   options: Options = {}
 ): ClipboardService {
-  const read = platform === "chrome" ? chromePlatform.readText : androidPlatform.readText;
-  const write = platform === "chrome" ? chromePlatform.writeText : androidPlatform.writeText;
+  const read =
+    platform === "chrome"
+      ? chromePlatform.readText
+      : androidPlatform.readText;
+  const write =
+    platform === "chrome"
+      ? chromePlatform.writeText
+      : androidPlatform.writeText;
 
   const watcher = createWatcher(read, options.pollIntervalMs ?? 2000);
   const writer = createWriter(write);


### PR DESCRIPTION
## Summary
- remove node clipboard platform
- monitor clipboard in Chrome extension via offscreen document
- create offscreen helper script to poll the system clipboard
- update background script to ensure offscreen document exists
- clean up dependencies

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686298859cb88328b37b92d9ec642f56