### PR TITLE
Fix offscreen script build

### DIFF
--- a/apps/extension/public/offscreen.html
+++ b/apps/extension/public/offscreen.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="UTF-8" />
-</head>
-<body>
-  <script type="module" src="../src/offscreen.ts"></script>
-</body>
-</html>

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -18,8 +18,8 @@ async function ensureOffscreen() {
   const has = await chrome.offscreen.hasDocument?.();
   if (!has) {
     await chrome.offscreen.createDocument({
-      url: "offscreen.html",
-      // url: chrome.runtime.getURL("offscreen.html"),
+      url: "src/offscreen.html",
+      // url: chrome.runtime.getURL("src/offscreen.html"),
       reasons: [chrome.offscreen.Reason.CLIPBOARD],
       justification: "monitor clipboard changes",
     });

--- a/apps/extension/vite.config.ts
+++ b/apps/extension/vite.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from "vite";
 import { crx } from "@crxjs/vite-plugin";
-import manifest from './manifest.json' with { type: 'json' };
-import polyfillNode from 'rollup-plugin-polyfill-node';
-import inject from '@rollup/plugin-inject';
-import { NodeGlobalsPolyfillPlugin } from '@esbuild-plugins/node-globals-polyfill';
+import manifest from "./manifest.json" with { type: "json" };
+import polyfillNode from "rollup-plugin-polyfill-node";
+import inject from "@rollup/plugin-inject";
+import { NodeGlobalsPolyfillPlugin } from "@esbuild-plugins/node-globals-polyfill";
+import { resolve } from "path";
 
 export default defineConfig({
   plugins: [crx({ manifest })],
@@ -19,6 +20,9 @@ export default defineConfig({
   build: {
     emptyOutDir: true,
     rollupOptions: {
+      input: {
+        offscreen: resolve(__dirname, "src/offscreen.html"),
+      },
       plugins: [
         polyfillNode(),
         inject({


### PR DESCRIPTION
## Summary
- compile `offscreen.ts` by adding it as a Vite build entry
- load `src/offscreen.html` from background script
- drop the unused copy of `offscreen.html`

## Testing
- `npm test`
- `npm run build -w apps/extension`

------
https://chatgpt.com/codex/tasks/task_e_6862c984f54083288c8becc5def7f517