### PR TITLE
Fix offscreen page creation

### DIFF
--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -26,6 +26,17 @@ async function ensureOffscreen() {
   }
 }
 
+// In MV3 the service worker may stop when idle and isn't guaranteed to start
+// automatically on browser launch. Listen for startup and install events to
+// create the offscreen document so clipboard monitoring works in the
+// background.
+chrome.runtime.onStartup.addListener(() => {
+  void ensureOffscreen();
+});
+chrome.runtime.onInstalled.addListener(() => {
+  void ensureOffscreen();
+});
+
 const clipboard = createClipboardService("chrome", {
   async sendClip(clip) {
     const id = await trust.getLocalIdentity();


### PR DESCRIPTION
## Summary
- ensure offscreen clipboard monitor is created on browser startup or install

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862d29281788328a0ca28bdcda38a71