### PR TITLE
Fix message types for pending trust requests

### DIFF
--- a/apps/extension/src/components/TrustPrompt.tsx
+++ b/apps/extension/src/components/TrustPrompt.tsx
@@ -6,14 +6,14 @@ export const TrustPrompt = () => {
 
   useEffect(() => {
     // @ts-ignore
-    chrome.runtime.sendMessage('getPendingRequests', (res) => {
+    chrome.runtime.sendMessage({ type: 'getPendingRequests' }, (res) => {
       setRequests(res || [])
     })
   }, [])
 
   function respond(dev: TrustedDevice, accept: boolean) {
     // @ts-ignore
-    chrome.runtime.sendMessage({ cmd: 'respondTrust', id: dev.deviceId, accept, device: dev }, () => {
+    chrome.runtime.sendMessage({ type: 'respondTrust', id: dev.deviceId, accept, device: dev }, () => {
       setRequests((r) => r.filter((p) => p.deviceId !== dev.deviceId))
     })
   }


### PR DESCRIPTION
## Summary
- ensure popup sends correct `type` for trust messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68635fbee77883289a58d43cb4c96b94