### PR TITLE
Fix base64url error in QR code functions

### DIFF
--- a/packages/core/qr/types.ts
+++ b/packages/core/qr/types.ts
@@ -18,14 +18,30 @@ export function isValidPayload(obj: any): obj is QRPayload {
   )
 }
 
+function toBase64Url(input: string): string {
+  return Buffer.from(input, 'utf8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '')
+}
+
+function fromBase64Url(b64url: string): string {
+  const b64 = b64url
+    .replace(/-/g, '+')
+    .replace(/_/g, '/')
+    .padEnd(Math.ceil(b64url.length / 4) * 4, '=')
+  return Buffer.from(b64, 'base64').toString('utf8')
+}
+
 export function payloadToBase64(payload: QRPayload): string {
   const json = JSON.stringify(payload)
-  return Buffer.from(json, 'utf8').toString('base64url')
+  return toBase64Url(json)
 }
 
 export function base64ToPayload(b64: string): QRPayload | null {
   try {
-    const json = Buffer.from(b64, 'base64url').toString('utf8')
+    const json = fromBase64Url(b64)
     const obj = JSON.parse(json)
     return isValidPayload(obj) ? obj : null
   } catch {


### PR DESCRIPTION
## Summary
- replace Node-only `base64url` Buffer encoding with custom helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863ec37a2c08328a166813ae5dd4b99