### PR TITLE
Add simple logging utility

### DIFF
--- a/apps/extension/src/offscreen.ts
+++ b/apps/extension/src/offscreen.ts
@@ -1,3 +1,5 @@
+import { info } from "../../../packages/core/logger";
+
 let lastText = "";
 
 async function checkClipboard() {
@@ -12,7 +14,7 @@ async function checkClipboard() {
   }
 }
 
-console.log("Clipboard monitoring started");
+info("Clipboard monitoring started");
 setInterval(checkClipboard, 2000);
 // initial check
 void checkClipboard();

--- a/packages/core/clipboard/service.ts
+++ b/packages/core/clipboard/service.ts
@@ -6,6 +6,7 @@ import { Clip } from "../models/Clip";
 import { ClipType } from "../models/enums";
 import * as chromePlatform from "./platform/chrome";
 import * as androidPlatform from "./platform/android";
+import * as log from "../logger";
 
 export interface ClipboardService {
   start(): void;
@@ -53,6 +54,7 @@ export function createClipboardService(
   const sendClip = options.sendClip ?? (async () => {});
 
   async function processLocalText(text: string): Promise<void> {
+    log.debug("Processing local clipboard text");
     const clip = normalizeClipboardContent(text, "local");
     if (!clip) return;
     if (clip.type !== ClipType.Text && clip.type !== ClipType.Url) return;
@@ -69,6 +71,7 @@ export function createClipboardService(
   });
 
   async function writeRemoteClip(clip: Clip): Promise<void> {
+    log.debug("Writing remote clip", clip.id);
     if (clip.id === lastLocal?.id) return;
     if (seenRemote.has(clip.id)) return;
     seenRemote.add(clip.id);
@@ -79,8 +82,14 @@ export function createClipboardService(
   }
 
   return {
-    start: () => watcher.start(),
-    stop: () => watcher.stop(),
+    start: () => {
+      log.info("Clipboard service started");
+      watcher.start();
+    },
+    stop: () => {
+      log.info("Clipboard service stopped");
+      watcher.stop();
+    },
     onLocalClip: (cb) => localHandlers.push(cb),
     onRemoteClipWritten: (cb) => remoteHandlers.push(cb),
     processLocalText,

--- a/packages/core/clipboard/watcher.ts
+++ b/packages/core/clipboard/watcher.ts
@@ -1,3 +1,5 @@
+import * as log from "../logger";
+
 export type ClipboardReader = () => Promise<string>;
 export type ChangeHandler = (text: string) => void;
 
@@ -35,6 +37,7 @@ export function createWatcher(
       const hash = hashString(text || "");
       if (hash !== lastHash) {
         lastHash = hash;
+        log.debug("Clipboard changed");
         handlers.forEach((h) => h(text));
       }
     } catch {
@@ -49,12 +52,14 @@ export function createWatcher(
           await check();
           timer = setInterval(check, intervalMs);
         })();
+        log.info("Clipboard watcher started");
       }
     },
     stop() {
       if (timer) {
         clearInterval(timer);
         timer = undefined;
+        log.info("Clipboard watcher stopped");
       }
     },
     onChange(cb: ChangeHandler) {

--- a/packages/core/clipboard/writer.ts
+++ b/packages/core/clipboard/writer.ts
@@ -1,5 +1,6 @@
 import { Clip } from "../models/Clip";
 import { ClipType } from "../models/enums";
+import * as log from "../logger";
 
 export type ClipboardWriteFn = (text: string) => Promise<void>;
 
@@ -11,6 +12,7 @@ export function createWriter(fn: ClipboardWriteFn): ClipboardWriter {
   return {
     async write(clip: Clip) {
       if (clip.type === ClipType.Text || clip.type === ClipType.Url) {
+        log.debug("Writing clip to clipboard");
         await fn(clip.content);
       }
     },

--- a/packages/core/logger.ts
+++ b/packages/core/logger.ts
@@ -1,0 +1,34 @@
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+let currentLevel: LogLevel = "info";
+
+const order: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+export function setLogLevel(level: LogLevel) {
+  currentLevel = level;
+}
+
+function shouldLog(level: LogLevel) {
+  return order[level] >= order[currentLevel];
+}
+
+export function debug(...args: unknown[]) {
+  if (shouldLog("debug")) console.debug(...args);
+}
+
+export function info(...args: unknown[]) {
+  if (shouldLog("info")) console.info(...args);
+}
+
+export function warn(...args: unknown[]) {
+  if (shouldLog("warn")) console.warn(...args);
+}
+
+export function error(...args: unknown[]) {
+  if (shouldLog("error")) console.error(...args);
+}

--- a/packages/core/trust/trusted-devices.ts
+++ b/packages/core/trust/trusted-devices.ts
@@ -1,5 +1,6 @@
 import { TypedEventEmitter } from './events'
 import { DeviceIdentity, getLocalIdentity } from './identity'
+import * as log from '../logger'
 
 export interface TrustedDevice extends DeviceIdentity {
   lastSeen?: number
@@ -92,6 +93,7 @@ export function createTrustManager(storage: StorageBackend): TrustManager {
       pending.delete(device.deviceId)
       pendingDevices.delete(device.deviceId)
     }
+    log.info("Device approved", device.deviceId)
     events.emit('approved', device)
   }
 
@@ -102,6 +104,7 @@ export function createTrustManager(storage: StorageBackend): TrustManager {
     if (idx >= 0) {
       list.splice(idx, 1)
       await save(list)
+      log.info("Device removed", id)
       events.emit('removed', device)
     }
   }
@@ -129,6 +132,7 @@ export function createTrustManager(storage: StorageBackend): TrustManager {
       events.emit('rejected', req)
     }, PENDING_TTL)
     pending.set(req.deviceId, timer)
+    log.info("Trust request from", req.deviceId)
     events.emit('request', req)
   }
 


### PR DESCRIPTION
## Summary
- add a basic logger with log levels
- replace `console` usage in libp2p engine with logger
- use logger in extension offscreen script
- expand logging across clipboard, network, and trust services

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6863f26ad9d88328ad42f342f721ed2d